### PR TITLE
Added menu.jspf and landing page text

### DIFF
--- a/aa-project-war/web/WEB-INF/jspf/menu.jspf
+++ b/aa-project-war/web/WEB-INF/jspf/menu.jspf
@@ -1,0 +1,14 @@
+<%-- 
+    Document   : menu.jspf
+    Created on : Nov 1, 2018, 14:35:36 PM
+    Author     : Dylan Van Assche
+
+    JSP fragments are placed by the JEE conventions into WEB-INF/jspf
+--%>
+
+<%@ page pageEncoding="UTF-8" %>
+<ul>
+    <li><a href="member">Members area</a></li>
+    <li><a href="order">Order tickets</a></li>
+    <li><a href="manage">Management area</a></li>
+</ul>

--- a/aa-project-war/web/WEB-INF/web.xml
+++ b/aa-project-war/web/WEB-INF/web.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <web-app version="3.1" xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
+    <description>Order your tickets for our upcoming plays!</description>
+    <display-name>Ticketmaster</display-name>
     <servlet>
         <description>The landing page of Ticketmaster</description>
         <servlet-name>Landing Servlet</servlet-name>
@@ -21,14 +23,6 @@
         <servlet-class>controller.ControllerMember</servlet-class>
     </servlet>
     <servlet-mapping>
-        <servlet-name>Landing Servlet</servlet-name>
-        <url-pattern>/</url-pattern>
-    </servlet-mapping>
-    <servlet-mapping>
-        <servlet-name>Management Servlet</servlet-name>
-        <url-pattern>/manage</url-pattern>
-    </servlet-mapping>
-    <servlet-mapping>
         <servlet-name>Order Servlet</servlet-name>
         <url-pattern>/order</url-pattern>
     </servlet-mapping>
@@ -36,9 +30,21 @@
         <servlet-name>Member Servlet</servlet-name>
         <url-pattern>/member</url-pattern>
     </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>Landing Servlet</servlet-name>
+        <url-pattern>/home</url-pattern>
+        <url-pattern>/</url-pattern>
+    </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>Management Servlet</servlet-name>
+        <url-pattern>/manage</url-pattern>
+    </servlet-mapping>
     <session-config>
         <session-timeout>
             30
         </session-timeout>
     </session-config>
+    <welcome-file-list>
+        <welcome-file>landing.jsp</welcome-file>
+    </welcome-file-list>
 </web-app>

--- a/aa-project-war/web/account.jsp
+++ b/aa-project-war/web/account.jsp
@@ -12,6 +12,8 @@
         <title>Account</title>
     </head>
     <body>
+        <!-- Menu -->
+        <%@include file="WEB-INF/jspf/menu.jspf" %>
         <h1>Welcome to Ticketmaster's account manager!</h1>
     </body>
 </html>

--- a/aa-project-war/web/confirm.jsp
+++ b/aa-project-war/web/confirm.jsp
@@ -12,6 +12,8 @@
         <title>Order confirmation</title>
     </head>
     <body>
+        <!-- Menu -->
+        <%@include file="WEB-INF/jspf/menu.jspf" %>
         <h1>Confirm your order below</h1>
     </body>
 </html>

--- a/aa-project-war/web/landing.jsp
+++ b/aa-project-war/web/landing.jsp
@@ -1,7 +1,7 @@
 <%-- 
     Document   : landing.jsp
     Created on : Oct 29, 2018, 6:44:36 PM
-    Author     : dylan
+    Author     : Dylan Van Assche
 --%>
 
 <%@page contentType="text/html" pageEncoding="UTF-8"%>
@@ -12,6 +12,11 @@
         <title>Home</title>
     </head>
     <body>
-        <h1>Landing page of Ticketmaster</h1>
+        <!-- Menu -->
+        <%@include file="WEB-INF/jspf/menu.jspf" %>
+        <h1>Welcome to TicketMaster!</h1>
+        <p>In this application you can order your tickets for our upcoming plays. Click on 'order' to proceed.</p>
+        <p>If you would like to check your previous orders, you can enter the 'members area' using your username and password.</p>
+        <p>Managing the application can be done in the 'management area'.</p>
     </body>
 </html>

--- a/aa-project-war/web/management.jsp
+++ b/aa-project-war/web/management.jsp
@@ -12,6 +12,8 @@
         <title>Management tool</title>
     </head>
     <body>
+        <!-- Menu -->
+        <%@include file="WEB-INF/jspf/menu.jspf" %>
         <h1>Welcome to the management tool for Ticketmaster, at your service!</h1>
     </body>
 </html>

--- a/aa-project-war/web/select-play.jsp
+++ b/aa-project-war/web/select-play.jsp
@@ -12,6 +12,8 @@
         <title>Play selection</title>
     </head>
     <body>
+        <!-- Menu -->
+        <%@include file="WEB-INF/jspf/menu.jspf" %>
         <h1>Select an upcoming play to continue</h1>
     </body>
 </html>

--- a/aa-project-war/web/select-seat.jsp
+++ b/aa-project-war/web/select-seat.jsp
@@ -12,6 +12,8 @@
         <title>Seat selection</title>
     </head>
     <body>
+        <!-- Menu -->
+        <%@include file="WEB-INF/jspf/menu.jspf" %>
         <h1>Select the seats for the chosen play</h1>
     </body>
 </html>


### PR DESCRIPTION
This PR adds the menu JSP fragment (in the WEB-INF/jspf folder by JEE convention).
The preliminary text for the landing page is added as well.

There's still a bug which needs to investigated, navigating from the landing page is still a problem (HTTP 404, due the missing project URL for some reason, the correct link is: `/aa-project/LINK`). Navigating in other pages works fine. This is probably a configuration issue I guess, we should ask this in the lab.

Reviews appreciated!